### PR TITLE
Add new bonus numbers in choose and go

### DIFF
--- a/src/commands/go.ts
+++ b/src/commands/go.ts
@@ -17,7 +17,7 @@ export async function commandGo(response: Response, team: string) {
       row: `Extremely likely winning row: ${generateNumbers(
         5,
         50
-      )} with bonus digits ${generateNumbers(2, 10)}`,
+      )} with bonus digits ${generateNumbers(2, 12)}`,
     });
   }
 

--- a/src/formatCustomInput.ts
+++ b/src/formatCustomInput.ts
@@ -50,7 +50,7 @@ export function formatCustomInput() {
           text: '*Choose a bonus number:*',
         },
       },
-      ...createSections(5, 10, 'bonus'),
+      ...createSections(5, 12, 'bonus'),
     ],
   };
 }


### PR DESCRIPTION
This PR will allow you to select 11 and 12 as bonus numbers and the same numbers to be randomly selected when running `/jackbot go`.